### PR TITLE
Enable cloudsmith repo as well to get current vespa versions.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM almalinux:8
 
 RUN dnf -y install epel-release && \
     dnf -y install dnf-plugins-core && \
+    dnf config-manager --add-repo https://raw.githubusercontent.com/vespa-engine/vespa/master/dist/vespa-engine.repo \
     dnf -y copr enable @vespa/vespa epel-8-$(arch)
 
 RUN --mount=type=bind,target=/include,source=.,ro \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM almalinux:8
 
 RUN dnf -y install epel-release && \
     dnf -y install dnf-plugins-core && \
-    dnf config-manager --add-repo https://raw.githubusercontent.com/vespa-engine/vespa/master/dist/vespa-engine.repo \
+    dnf config-manager --add-repo https://raw.githubusercontent.com/vespa-engine/vespa/master/dist/vespa-engine.repo && \
     dnf -y copr enable @vespa/vespa epel-8-$(arch)
 
 RUN --mount=type=bind,target=/include,source=.,ro \

--- a/screwdriver.yaml
+++ b/screwdriver.yaml
@@ -24,6 +24,7 @@ jobs:
           export VESPA_VERSION=$(meta get vespa.version --external sd@6386:publish-release)
           echo "Building for version $VESPA_VERSION"
       - install-dependencies: |
+          dnf config-manager --add-repo https://raw.githubusercontent.com/vespa-engine/vespa/master/dist/vespa-engine.repo
           dnf config-manager --add-repo https://download.docker.com/linux/centos/docker-ce.repo
           dnf -y install docker-ce docker-ce-cli containerd.io
           docker system info


### PR DESCRIPTION
I confirm that this contribution is made under the terms of the license found in the root directory of this repository's source tree and that I have the authority necessary to make this contribution on behalf of its copyright owner.
